### PR TITLE
ppc64le sync grub.cfg changes to disk (#1212114)

### DIFF
--- a/new-kernel-pkg
+++ b/new-kernel-pkg
@@ -927,4 +927,12 @@ fi
 # if we mounted the U-Boot directory, unmount it.
 [ -n "$mounted" ] && umount $ubootDir
 
+# make sure changes make it to the disk.
+# if /boot is a mountpoint, force the meta data on disk
+# to by-pass writeback delay.
+# PPC64LE-only to deal with Petitboot issues
+if [ "$ARCH" = "ppc64le" ]; then
+    sync && mountpoint -q /boot &&fsfreeze -f /boot && fsfreeze -u /boot
+fi
+
 exit 0


### PR DESCRIPTION
After installing a new kernel, if a panic is induced, not all the kernel
pieces are on the disk (most importantly the grub.cfg changes).  This can
lead to a hung system on a reboot because the older kernel can not be found.

Address this by forcing all the changes (mainly the fs meta data) to disk
before finishing the kernel package installation.

Tested by 'yum install kernel-...; echo c > /proc/sysrq-trigger'.

Before, the machine would panic and on reboot be stuck without a grub.cfg
to read.  After, works as expected.

Resolves: rhbz#1212114