### PR TITLE
Patch Series: grubby selects wrong default entry

### DIFF
--- a/grubby.8
+++ b/grubby.8
@@ -145,7 +145,8 @@ boot entry. This may not be invoked with \fB-\-set-default-index\fR.
 .TP
 \fB-\-set-default-index\fR=\fIentry-index\fR
 Makes the given entry number the default boot entry. This may not
-be invoked with \fB-\-set-default\fR.
+be invoked with \fB-\-set-default\fR. Assumes the index provided
+is based on the post-modification boot entry list.
 
 .TP
 \fB-\-make-default\fR

--- a/grubby.c
+++ b/grubby.c
@@ -2589,19 +2589,19 @@ void markRemovedImage(struct grubConfig *cfg, const char *image,
 		entry->skip = 1;
 }
 
-void setDefaultImage(struct grubConfig *config, int hasNew,
-		     const char *defaultKernelPath, int newIsDefault,
-		     const char *prefix, int flags, int index)
+void setDefaultImage(struct grubConfig *config, int isUserSpecifiedKernelPath,
+		     const char *defaultKernelPath, int newBootEntryIsDefault,
+		     const char *prefix, int flags, int newDefaultBootEntryIndex)
 {
 	struct singleEntry *entry, *entry2, *newDefault;
 	int i, j;
 
-	if (newIsDefault) {
+	if (newBootEntryIsDefault) {
 		config->defaultImage = 0;
 		return;
-	} else if ((index >= 0) && config->cfi->defaultIsIndex) {
-		if (findEntryByIndex(config, index))
-			config->defaultImage = index;
+	} else if ((newDefaultBootEntryIndex >= 0) && config->cfi->defaultIsIndex) {
+		if (findEntryByIndex(config, newDefaultBootEntryIndex))
+			config->defaultImage = newDefaultBootEntryIndex;
 		else
 			config->defaultImage = -1;
 		return;
@@ -2629,7 +2629,7 @@ void setDefaultImage(struct grubConfig *config, int hasNew,
 
 	if (entry && !entry->skip) {
 		/* we can preserve the default */
-		if (hasNew)
+		if (isUserSpecifiedKernelPath)
 			config->defaultImage++;
 
 		/* count the number of entries erased before this one */
@@ -2638,7 +2638,7 @@ void setDefaultImage(struct grubConfig *config, int hasNew,
 			if (entry2->skip)
 				config->defaultImage--;
 		}
-	} else if (hasNew) {
+	} else if (isUserSpecifiedKernelPath) {
 		config->defaultImage = 0;
 	} else {
 		/* Either we just erased the default (or the default line was bad

--- a/grubby.c
+++ b/grubby.c
@@ -130,6 +130,10 @@ struct singleEntry {
 #define NEED_END     (1 << 5)
 
 #define MAIN_DEFAULT	    (1 << 0)
+#define FIRST_ENTRY_INDEX    0          /* boot entry index value begin and increment from
+                                           this initial value */
+#define NO_DEFAULT_ENTRY    -1          /* indicates that no specific default boot entry
+                                           was set or currently exists */
 #define DEFAULT_SAVED       -2
 #define DEFAULT_SAVED_GRUB2 -3
 
@@ -1712,7 +1716,7 @@ static struct grubConfig *readConfig(const char *inName,
 						*end == ' ' || *end == '\t'))
 					end++;
 				if (*end)
-					cfg->defaultImage = -1;
+					cfg->defaultImage = NO_DEFAULT_ENTRY;
 			} else if (defaultLine->numElements == 3) {
 				char *value = defaultLine->elements[2].item;
 				while (*value && (*value == '"' ||
@@ -1725,7 +1729,7 @@ static struct grubConfig *readConfig(const char *inName,
 						*end == ' ' || *end == '\t'))
 					end++;
 				if (*end)
-					cfg->defaultImage = -1;
+					cfg->defaultImage = NO_DEFAULT_ENTRY;
 			}
 		} else if (cfi->defaultSupportSaved &&
 			   !strncmp(defaultLine->elements[1].item, "saved",
@@ -1735,7 +1739,7 @@ static struct grubConfig *readConfig(const char *inName,
 			cfg->defaultImage =
 			    strtol(defaultLine->elements[1].item, &end, 10);
 			if (*end)
-				cfg->defaultImage = -1;
+				cfg->defaultImage = NO_DEFAULT_ENTRY;
 		} else if (defaultLine->numElements >= 2) {
 			int i = 0;
 			while ((entry = findEntryByIndex(cfg, i))) {
@@ -1763,7 +1767,7 @@ static struct grubConfig *readConfig(const char *inName,
 			if (entry) {
 				cfg->defaultImage = i;
 			} else {
-				cfg->defaultImage = -1;
+				cfg->defaultImage = NO_DEFAULT_ENTRY;
 			}
 		}
 	} else if (cfg->cfi->defaultIsSaved && cfg->cfi->getEnv) {
@@ -1780,7 +1784,7 @@ static struct grubConfig *readConfig(const char *inName,
 				cfg->defaultImage = index;
 		}
 	} else {
-		cfg->defaultImage = 0;
+		cfg->defaultImage = FIRST_ENTRY_INDEX;
 	}
 
 	return cfg;
@@ -1800,7 +1804,7 @@ static void writeDefault(FILE * out, char *indent,
 		fprintf(out, "%sdefault%ssaved\n", indent, separator);
 	else if (cfg->cfi->defaultIsSaved) {
 		fprintf(out, "%sset default=\"${saved_entry}\"\n", indent);
-		if (cfg->defaultImage >= 0 && cfg->cfi->setEnv) {
+		if (cfg->defaultImage >= FIRST_ENTRY_INDEX && cfg->cfi->setEnv) {
 			char *title;
 			entry = findEntryByIndex(cfg, cfg->defaultImage);
 			line = getLineByType(LT_MENUENTRY, entry->lines);
@@ -1813,7 +1817,7 @@ static void writeDefault(FILE * out, char *indent,
 							 "saved_entry", title);
 			}
 		}
-	} else if (cfg->defaultImage > -1) {
+	} else if (cfg->defaultImage >= FIRST_ENTRY_INDEX) {
 		if (cfg->cfi->defaultIsIndex) {
 			if (cfg->cfi->defaultIsVariable) {
 				fprintf(out, "%sset default=\"%d\"\n", indent,
@@ -2515,7 +2519,7 @@ struct singleEntry *findTemplate(struct grubConfig *cfg, const char *prefix,
 				}
 			}
 		}
-	} else if (cfg->defaultImage > -1) {
+	} else if (cfg->defaultImage >= FIRST_ENTRY_INDEX) {
 		entry = findEntryByIndex(cfg, cfg->defaultImage);
 		if (entry && suitableImage(entry, prefix, skipRemoved, flags)) {
 			if (indexPtr)
@@ -2597,20 +2601,20 @@ void setDefaultImage(struct grubConfig *config, int isUserSpecifiedKernelPath,
 	int i, j;
 
 	if (newBootEntryIsDefault) {
-		config->defaultImage = 0;
+		config->defaultImage = FIRST_ENTRY_INDEX;
 		return;
 	} else if ((newDefaultBootEntryIndex >= 0) && config->cfi->defaultIsIndex) {
 		if (findEntryByIndex(config, newDefaultBootEntryIndex))
 			config->defaultImage = newDefaultBootEntryIndex;
 		else
-			config->defaultImage = -1;
+			config->defaultImage = NO_DEFAULT_ENTRY;
 		return;
 	} else if (defaultKernelPath) {
 		i = 0;
 		if (findEntryByPath(config, defaultKernelPath, prefix, &i)) {
 			config->defaultImage = i;
 		} else {
-			config->defaultImage = -1;
+			config->defaultImage = NO_DEFAULT_ENTRY;
 			return;
 		}
 	}
@@ -2622,7 +2626,7 @@ void setDefaultImage(struct grubConfig *config, int isUserSpecifiedKernelPath,
 		/* default is set to saved, we don't want to change it */
 		return;
 
-	if (config->defaultImage > -1)
+	if (config->defaultImage >= FIRST_ENTRY_INDEX)
 		entry = findEntryByIndex(config, config->defaultImage);
 	else
 		entry = NULL;
@@ -2639,7 +2643,7 @@ void setDefaultImage(struct grubConfig *config, int isUserSpecifiedKernelPath,
 				config->defaultImage--;
 		}
 	} else if (isUserSpecifiedKernelPath) {
-		config->defaultImage = 0;
+		config->defaultImage = FIRST_ENTRY_INDEX;
 	} else {
 		/* Either we just erased the default (or the default line was bad
 		 * to begin with) and didn't put a new one in. We'll use the first
@@ -2648,7 +2652,7 @@ void setDefaultImage(struct grubConfig *config, int isUserSpecifiedKernelPath,
 		    findTemplate(config, prefix, &config->defaultImage, 1,
 				 flags);
 		if (!newDefault)
-			config->defaultImage = -1;
+			config->defaultImage = NO_DEFAULT_ENTRY;
 	}
 }
 
@@ -5210,11 +5214,11 @@ int main(int argc, const char **argv)
 		struct singleEntry *entry;
 		char *rootspec;
 
-		if (config->defaultImage == -1)
+		if (config->defaultImage == NO_DEFAULT_ENTRY)
 			return 0;
 		if (config->defaultImage == DEFAULT_SAVED_GRUB2 &&
 		    cfi->defaultIsSaved)
-			config->defaultImage = 0;
+			config->defaultImage = FIRST_ENTRY_INDEX;
 		entry = findEntryByIndex(config, config->defaultImage);
 		if (!entry)
 			return 0;
@@ -5237,11 +5241,11 @@ int main(int argc, const char **argv)
 		struct singleLine *line;
 		struct singleEntry *entry;
 
-		if (config->defaultImage == -1)
+		if (config->defaultImage == NO_DEFAULT_ENTRY)
 			return 0;
 		if (config->defaultImage == DEFAULT_SAVED_GRUB2 &&
 		    cfi->defaultIsSaved)
-			config->defaultImage = 0;
+			config->defaultImage = FIRST_ENTRY_INDEX;
 		entry = findEntryByIndex(config, config->defaultImage);
 		if (!entry)
 			return 0;
@@ -5271,11 +5275,11 @@ int main(int argc, const char **argv)
 		return 0;
 
 	} else if (displayDefaultIndex) {
-		if (config->defaultImage == -1)
+		if (config->defaultImage == NO_DEFAULT_ENTRY)
 			return 0;
 		if (config->defaultImage == DEFAULT_SAVED_GRUB2 &&
 		    cfi->defaultIsSaved)
-			config->defaultImage = 0;
+			config->defaultImage = FIRST_ENTRY_INDEX;
 		printf("%i\n", config->defaultImage);
 		return 0;
 

--- a/grubby.c
+++ b/grubby.c
@@ -2596,67 +2596,122 @@ void markRemovedImage(struct grubConfig *cfg, const char *image,
 		entry->skip = 1;
 }
 
-void setDefaultImage(struct grubConfig *config, int isUserSpecifiedKernelPath,
+void setDefaultImage(struct grubConfig *config, int isAddingBootEntry,
 		     const char *defaultKernelPath, int newBootEntryIsDefault,
-		     const char *prefix, int flags, int newDefaultBootEntryIndex)
+		     const char *prefix, int flags, int newDefaultBootEntryIndex,
+                     int newBootEntryIndex)
 {
-	struct singleEntry *entry, *entry2, *newDefault;
-	int i, j;
+	struct singleEntry *bootEntry, *newDefault;
+	int indexToVerify, firstKernelEntryIndex, currentLookupIndex;
 
-	if (newBootEntryIsDefault) {
-		config->defaultImage = FIRST_ENTRY_INDEX;
-		return;
-	} else if ((newDefaultBootEntryIndex >= 0) && config->cfi->defaultIsIndex) {
-		if (findEntryByIndex(config, newDefaultBootEntryIndex))
+        /* handle the two cases where the user explictly picks the default
+         * boot entry index as it would exist post-modification */
+
+        /* Case 1: user chose to make the latest boot entry the default */
+        if (newBootEntryIsDefault) {
+                config->defaultImage = newBootEntryIndex;
+                return;
+        }
+
+        /* Case 2: user picked an arbitrary index as the default boot entry */
+        if ((newDefaultBootEntryIndex >= FIRST_ENTRY_INDEX) && config->cfi->defaultIsIndex) {
+
+                indexToVerify = newDefaultBootEntryIndex;
+
+                /* user chose to make latest boot entry the default */
+                if (newDefaultBootEntryIndex == newBootEntryIndex) {
+                        config->defaultImage = newBootEntryIndex;
+                        return;
+                }
+
+                /* the user picks the default index based on the
+                 * order of the bootloader configuration after
+                 * modification; ensure we are checking for the
+                 * existence of the correct entry */
+                if (newBootEntryIndex < newDefaultBootEntryIndex) {
+                        if (!config->isModified)
+                                indexToVerify--;
+                }
+
+                /* verify the user selected index will exist */
+		if (findEntryByIndex(config, indexToVerify)) {
 			config->defaultImage = newDefaultBootEntryIndex;
-		else
-			config->defaultImage = NO_DEFAULT_ENTRY;
-		return;
-	} else if (defaultKernelPath) {
-		i = 0;
-		if (findEntryByPath(config, defaultKernelPath, prefix, &i)) {
-			config->defaultImage = i;
-		} else {
-			config->defaultImage = NO_DEFAULT_ENTRY;
-			return;
-		}
-	}
+                } else {
+                        config->defaultImage = NO_DEFAULT_ENTRY;
+                }
 
-	/* defaultImage now points to what we'd like to use, but before any order 
-	   changes */
-	if ((config->defaultImage == DEFAULT_SAVED) ||
-	    (config->defaultImage == DEFAULT_SAVED_GRUB2))
-		/* default is set to saved, we don't want to change it */
-		return;
+                return;
+        }
 
-	if (config->defaultImage >= FIRST_ENTRY_INDEX)
-		entry = findEntryByIndex(config, config->defaultImage);
-	else
-		entry = NULL;
+        /* handle cases where the index value may shift */
 
-	if (entry && !entry->skip) {
-		/* we can preserve the default */
-		if (isUserSpecifiedKernelPath)
-			config->defaultImage++;
+        /* check validity of existing default or first-entry-found selection */
+        if (defaultKernelPath) {
+                /* user requested first-entry-found */
+		if (!findEntryByPath(config, defaultKernelPath,
+                                    prefix, &firstKernelEntryIndex)) {
+                        /* don't change default if can't find match */
+                        config->defaultImage = NO_DEFAULT_ENTRY;
+                        return;
+                }
 
-		/* count the number of entries erased before this one */
-		for (j = 0; j < config->defaultImage; j++) {
-			entry2 = findEntryByIndex(config, j);
-			if (entry2->skip)
-				config->defaultImage--;
-		}
-	} else if (isUserSpecifiedKernelPath) {
-		config->defaultImage = FIRST_ENTRY_INDEX;
-	} else {
-		/* Either we just erased the default (or the default line was bad
-		 * to begin with) and didn't put a new one in. We'll use the first
-		 * valid image. */
+                config->defaultImage = firstKernelEntryIndex;
+
+                /* this is where we start looking for decrement later */
+                currentLookupIndex = config->defaultImage;
+
+                if (isAddingBootEntry && !config->isModified &&
+                                (newBootEntryIndex < config->defaultImage)) {
+                        /* increment because new entry added before default */
+                        config->defaultImage++;
+                }
+        } else {
+                /* use pre-existing default entry */
+                currentLookupIndex = config->defaultImage;
+
+                if (isAddingBootEntry && (newBootEntryIndex <= config->defaultImage)) {
+                        config->defaultImage++;
+
+                        if (config->isModified) {
+                                currentLookupIndex++;
+                        }
+                }
+        }
+
+        /* sanity check - is this entry index valid? */
+        bootEntry = findEntryByIndex(config, currentLookupIndex);
+
+        if ((bootEntry && bootEntry->skip) || !bootEntry) {
+                /* entry is to be skipped or is invalid */
+                if (isAddingBootEntry) {
+                        config->defaultImage = newBootEntryIndex;
+                        return;
+                }
 		newDefault =
 		    findTemplate(config, prefix, &config->defaultImage, 1,
 				 flags);
-		if (!newDefault)
+		if (!newDefault) {
 			config->defaultImage = NO_DEFAULT_ENTRY;
-	}
+                }
+
+                return;
+        }
+
+        currentLookupIndex--;
+
+        /* decrement index by the total number of entries deleted */
+
+        for (indexToVerify = currentLookupIndex;
+                        indexToVerify >= FIRST_ENTRY_INDEX;
+                        indexToVerify--) {
+
+                bootEntry = findEntryByIndex(config, indexToVerify);
+
+                if (bootEntry && bootEntry->skip)
+                {
+                        config->defaultImage--;
+                }
+        }
 }
 
 void setFallbackImage(struct grubConfig *config, int hasNew)
@@ -5301,7 +5356,7 @@ int main(int argc, const char **argv)
 	markRemovedImage(config, removeKernelPath, bootPrefix);
 	markRemovedImage(config, removeMBKernel, bootPrefix);
 	setDefaultImage(config, newKernelPath != NULL, defaultKernel,
-			makeDefault, bootPrefix, flags, defaultIndex);
+			makeDefault, bootPrefix, flags, defaultIndex, newIndex);
 	setFallbackImage(config, newKernelPath != NULL);
 	if (updateImage(config, updateKernelPath, bootPrefix, newKernelArgs,
 			removeArgs, newMBKernelArgs, removeMBKernelArgs))

--- a/grubby.c
+++ b/grubby.c
@@ -671,6 +671,8 @@ struct grubConfig {
 	int fallbackImage;	/* just like defaultImage */
 	int flags;
 	struct configFileInfo *cfi;
+        int isModified;         /* assumes only one entry added
+                                   per invocation of grubby */
 };
 
 blkid_cache blkid;
@@ -1399,6 +1401,7 @@ static struct grubConfig *readConfig(const char *inName,
 	cfg->theLines = NULL;
 	cfg->entries = NULL;
 	cfg->fallbackImage = 0;
+        cfg->isModified = 0;
 
 	/* copy everything we have */
 	while (*head) {
@@ -4765,7 +4768,10 @@ int addNewKernel(struct grubConfig *config, struct singleEntry *template,
 
 	if (updateImage(config, indexs, prefix, newKernelArgs, NULL,
 			newMBKernelArgs, NULL))
+        {
+                config->isModified = 1;
 		return 1;
+        }
 
 	return 0;
 }

--- a/test/results/add/g1.17
+++ b/test/results/add/g1.17
@@ -7,7 +7,7 @@
 #          kernel /vmlinuz-version ro root=/dev/sda1
 #          initrd /initrd-version.img
 #boot=/dev/hda
-default=1
+default=0
 timeout=10
 splashimage=(hd0,0)/grub/splash.xpm.gz
 title Red Hat Linux (2.4.7-2)

--- a/test/results/add/g1.9
+++ b/test/results/add/g1.9
@@ -7,7 +7,7 @@
 #          kernel /vmlinuz-version ro root=/dev/sda1
 #          initrd /initrd-version.img
 #boot=/dev/hda
-default=2
+default=1
 timeout=10
 splashimage=(hd0,0)/grub/splash.xpm.gz
 title Red Hat Linux (2.4.7-2)

--- a/test/results/remove/g7.1
+++ b/test/results/remove/g7.1
@@ -1,4 +1,4 @@
-default=1
+default=0
 timeout=10
 splashimage=(hd0,5)/boot/grub/splash.xpm.gz
 


### PR DESCRIPTION
A logic issue caused --add-kernel to always set the new boot entry as the default.

Refactored to correct this issue as well as resolve some other corner cases with removing kernels where the default kernel would be incorrect.

